### PR TITLE
Use percentile breaks for colorstep legend

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -12,56 +12,74 @@ date_end <- as.Date("2022-05-01") # Need to keep as first date of following mont
 
 # wet to dry color scale
 pal_wetdry <- c("#002D5E", "#0C7182", "#6CB7B0", "#A7D2D8", "#E0D796", "#AF9423", "#A84E0B")
+percentile_breaks = c(0, 0.05, 0.1, 0.25, 0.75, 0.9, 0.95, 1)
 color_bknd <- "#F4F4F4"
 text_color = "#444444"
 
 # to produce the flow cartogram, run tar_make() in the console
 list(
+  # Read in data from gage-flow-conditions pipeline output
   tar_target(
     dv,
-    read_csv("https://labs.waterdata.usgs.gov/visualizations/data/flow_conditions_202204.csv", col_types = "cTnnnnT")
+    read_csv("https://labs.waterdata.usgs.gov/visualizations/data/flow_conditions_202204.csv", col_types = "cTnnnn")
   ),
+  # Bin percentile data 
   tar_target(
     flow,
-    add_flow_condition(dv, date_start, date_end)
+    add_flow_condition(dv, date_start, date_end, breaks = percentile_breaks)
   ),
+  # Find list of all active sites
+  tar_target(
+    site_list,
+    unique(flow$site_no)
+  ),
+  # Pull site info (state) 
   tar_target(
     dv_site,
-    dataRetrieval::readNWISsite(siteNumbers = unique(flow$site_no)) %>%
+    dataRetrieval::readNWISsite(siteNumbers = site_list) %>%
       distinct(site_no, state_cd)
   ),
+  # Count the number of sites in each state
   tar_target(
     sites_state,
     site_count_state(flow, dv_site)
   ),
+  # Count total number of sites nationally
   tar_target(
     sites_national,
     site_count_national(sites_state)
   ),
+  # Find the proportion of sites in each flow category nationally
   tar_target(
     flow_national,
     flow_by_day(flow, sites_national)
   ),
+  # Find the proportion of sites in each flow category by each state
   tar_target(
     flow_state,
     flow_by_day_by_state(flow, dv_site, sites_state)
   ),
+  # Define grid for tile positioning
   tar_target(
     usa_grid,
     make_carto_grid()
   ),
+  # Pull fips codes to join state data to grid
   tar_target(
     fips,
     get_state_fips()
   ),
+  # Plot flow tiemseries for states
   tar_target(
     plot_cart,
     plot_state_cartogram(state_data = flow_state, fips, pal = pal_wetdry, usa_grid, color_bknd)
   ),
+  # Plot flow timeseries natioanlly
   tar_target(
     plot_nat,
     plot_national_area(national_data = flow_national, pal = pal_wetdry, date_start, date_end, color_bknd)
   ),
+  # Combine charts and assemble final plot
   tar_target(
     flow_cartogram_svg,
     combine_plots(file_out = "flow_cartogram.svg", 

--- a/_targets.R
+++ b/_targets.R
@@ -13,6 +13,7 @@ date_end <- as.Date("2022-05-01") # Need to keep as first date of following mont
 # wet to dry color scale
 pal_wetdry <- c("#002D5E", "#0C7182", "#6CB7B0", "#A7D2D8", "#E0D796", "#AF9423", "#A84E0B")
 percentile_breaks = c(0, 0.05, 0.1, 0.25, 0.75, 0.9, 0.95, 1)
+percentile_labels <- c("Driest", "Drier", "Dry", "Normal","Wet","Wetter", "Wettest")
 color_bknd <- "#F4F4F4"
 text_color = "#444444"
 
@@ -26,7 +27,7 @@ list(
   # Bin percentile data 
   tar_target(
     flow,
-    add_flow_condition(dv, date_start, date_end, breaks = percentile_breaks)
+    add_flow_condition(dv, date_start, date_end, breaks = percentile_breaks, break_labels = percentile_labels)
   ),
   # Find list of all active sites
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -74,7 +74,7 @@ list(
     plot_cart,
     plot_state_cartogram(state_data = flow_state, fips, pal = pal_wetdry, usa_grid, color_bknd)
   ),
-  # Plot flow timeseries natioanlly
+  # Plot flow timeseries nationally
   tar_target(
     plot_nat,
     plot_national_area(national_data = flow_national, pal = pal_wetdry, date_start, date_end, color_bknd)

--- a/src/plot_cartogram.R
+++ b/src/plot_cartogram.R
@@ -42,8 +42,9 @@ plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
       colour = "black",
       x_offset = 2,
       y_offset = 2,
-      sigma = 10,
-      stack = TRUE
+      sigma = 5,
+      stack = TRUE,
+      with_background = FALSE
     ) +
     scale_fill_manual(values = rev(pal)) +
     facet_geo(~abb, grid = usa_grid, move_axes = FALSE) +
@@ -53,7 +54,9 @@ plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
           panel.spacing.y = unit(-5, "pt"),
           panel.spacing.x = unit(4, "pt"),
           strip.text = element_text(vjust = -1),
-          legend.position = 'none')+
+          legend.position = 'none',
+          #strip.clip = 'off'
+          )+
     coord_fixed(ratio = 28)
 
 }
@@ -151,9 +154,10 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
                                 title = "",
                                 nrow = 1,
                                 direction = 'horizontal',
-                                box.background = element_blank(),
+                                box.background = element_rect(fill = NA),
                                 label.position = "bottom"
                               )))
+
   # compose final plot
   ggdraw(ylim = c(0,1), 
          xlim = c(0,1)) +

--- a/src/plot_cartogram.R
+++ b/src/plot_cartogram.R
@@ -29,7 +29,7 @@ theme_flowfacet <- function(base = 12, color_bknd, text_color){
           panel.spacing.x = unit(-2, "pt"),
           panel.spacing.y = unit(-5, "pt"),
           plot.margin = margin(0, 0, 0, 0, "pt"),
-          legend.box.background = element_rect(fill = NA, color = NA))
+          legend.box.background = element_rect(fill = color_bknd, color = NA))
           
  }
 
@@ -38,7 +38,7 @@ plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
     left_join(fips) %>% # to bind to cartogram grid
     ggplot(aes(date, prop)) +
     with_shadow(
-      geom_area(aes(fill = cond)),
+      geom_area(aes(fill = percentile_cond)),
       colour = "black",
       x_offset = 2,
       y_offset = 2,
@@ -54,8 +54,7 @@ plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
           panel.spacing.y = unit(-5, "pt"),
           panel.spacing.x = unit(4, "pt"),
           strip.text = element_text(vjust = -1),
-          legend.position = 'none',
-          #strip.clip = 'off'
+          legend.position = 'none'
           )+
     coord_fixed(ratio = 28)
 
@@ -66,22 +65,12 @@ plot_national_area <- function(national_data, date_start, date_end, pal, color_b
   # to label flow categories
   sec_labels <- national_data  %>%
     filter(date == max(national_data$date)) %>%
-    distinct(cond, prop) %>%
-    mutate(prop = cumsum(prop)) %>%
-    # control positions of categorical labels
-    mutate(position = case_when(
-      cond == 'Wettest' ~ 1,
-      cond == 'Driest' ~ 0,
-      cond == 'Wetter' & prop > 0.95 ~ 0.95,
-      cond == 'Wet' & prop > 0.9 ~ 0.9,
-      cond == 'Drier' & prop < 0.05 ~ 0.05,
-      cond == 'Dry' & prop < 0.1 ~ 0.1,
-      TRUE ~ prop
-    ))
+    distinct(percentile_cond, prop) %>%
+    mutate(prop = cumsum(prop))
   
   plot_nat <- national_data %>% 
     ggplot(aes(date, prop)) +
-    geom_area(aes(fill = cond)) +
+    geom_area(aes(fill = percentile_bin)) +
     theme_classic() +
     labs(x = lubridate::month(date_end - 30, label = TRUE, abbr = FALSE),
          y="") +
@@ -90,7 +79,7 @@ plot_national_area <- function(national_data, date_start, date_end, pal, color_b
                        breaks = rev(c(0.05,0.08, 0.15, 0.5, 0.75, 0.92, 0.95)), 
                        labels = c("0%","","","","", "","100%"),
                        sec.axis = dup_axis(
-                         labels = sec_labels$cond
+                         labels = sec_labels$percentile_cond
                        )) +
     theme_flowfacet(base = 12, color_bknd, text_color) +
     theme(axis.text.y = 
@@ -113,7 +102,6 @@ plot_national_area <- function(national_data, date_start, date_end, pal, color_b
                  sec.axis = dup_axis(
                    name = "National"
                  )) +
-    guides(fill = guide_legend("")) +
     coord_fixed(ratio = 28, clip = "off")
   
   
@@ -133,7 +121,7 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
   
   text_color <- "#444444"
   
-  # logo
+  # usgs logo
   usgs_logo <- magick::image_read('in/usgs_logo.png') %>%
     magick::image_colorize(100, text_color)
   
@@ -148,15 +136,25 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
     width = 16, height = 9,
     gp = grid::gpar(fill = color_bknd, alpha = 1, col = color_bknd)
   )
-  # get legend
-  plot_legend <- get_legend(plot_left +
-                              guides(fill = guide_legend(
-                                title = "",
-                                nrow = 1,
-                                direction = 'horizontal',
-                                box.background = element_rect(fill = NA),
-                                label.position = "bottom"
-                              )))
+  
+  # Restyle legend
+  plot_left <- plot_left +
+    guides(fill = guide_colorsteps(
+      title = "",
+      nrow = 1,
+      direction = 'horizontal',
+      label.position = "bottom",
+      barwidth = 22,
+      barheight = 1,
+      background = element_rect(fill = NA),
+      show.limits = TRUE,
+      even.steps = FALSE
+    )) +
+      theme(legend.background = element_rect(fill = NA),
+            text = element_text(family = font_legend, color = text_color))
+  
+  # Extract from plot
+  plot_legend <- get_legend(plot_left)
 
   # compose final plot
   ggdraw(ylim = c(0,1), 
@@ -167,26 +165,25 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
               height = 9, width = 16,
               hjust = 0, vjust = 1) +
     # national-level plot
-    draw_plot(plot_left+theme(text = element_text(family = font_legend, color = text_color),
-                              legend.position = 'none'),
+    draw_plot(plot_left+theme(legend.position = 'none'),
               x = plot_margin*2,
               y = 0.25,
               height = 0.45 ,
               width = 0.3-plot_margin*2) +
     # state tiles
-    draw_plot(plot_right+theme(text = element_text(family = font_legend, color = text_color)),
-              x = 1,
-              y = 0+plot_margin,
-              height = 1- plot_margin*4, 
-              width = 1-(0.3+plot_margin*4),
-              hjust = 1,
-              vjust = 0) +
+   draw_plot(plot_right+theme(text = element_text(family = font_legend, color = text_color)),
+             x = 1,
+             y = 0+plot_margin,
+             height = 1- plot_margin*4, 
+             width = 1-(0.3+plot_margin*4),
+             hjust = 1,
+             vjust = 0) +
     # add legend
     draw_plot(plot_legend,
               x = plot_margin*2,
               y = 0.1,
-              height = 0.1 ,
-              width = 0.3-plot_margin*2) +
+              height = 0.13 ,
+              width = 0.3-plot_margin) +
     # draw title
    draw_label(sprintf('%s %s', plot_month, plot_year),
               x = plot_margin*2, y = 1-plot_margin*4, 

--- a/src/plot_cartogram.R
+++ b/src/plot_cartogram.R
@@ -184,7 +184,7 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
     # add legend
     draw_plot(plot_legend,
               x = plot_margin*2,
-              y = 0.15,
+              y = 0.1,
               height = 0.1 ,
               width = 0.3-plot_margin*2) +
     # draw title
@@ -204,6 +204,14 @@ combine_plots <- function(file_out, plot_left, plot_right, date_start, width, he
                width = 0.55,
                hjust = 0,
                vjust = 1) +
+    # percentile info
+    draw_label("Flow percentile at USGS streamgages\nrelative to the historic daily record.", 
+               x = plot_margin*2,
+               y = 0.25,
+               hjust = 0,
+               vjust = 1,
+               fontfamily = font_legend,
+               color = text_color) +
     # add data source
     draw_label("Data: USGS National Water Information System", 
                x = 1-plot_margin*2, y = plot_margin*2, 

--- a/src/plot_cartogram.R
+++ b/src/plot_cartogram.R
@@ -1,8 +1,11 @@
+#' @description Create tile grid for state map
 make_carto_grid <- function(){
   us_state_grid1 %>% 
     add_row(row = 7, col = 11, code = "PR", name = "Puerto Rico") %>% # add PR
     filter(code != "DC") # remove DC (only has 3 gages)
 }
+
+#' @description Pull state fips code to bind to state grid
 get_state_fips <- function(){
   maps::state.fips %>% 
     distinct(fips, abb) %>%
@@ -12,6 +15,10 @@ get_state_fips <- function(){
     mutate(state_cd = str_pad(fips, 2, "left", pad = "0"))
 }
 
+#' @description Basic plotting theme
+#' @param base Font size for relative scaling
+#' @param color_bknd The final plot background color
+#' @param text_color Color for the font
 theme_flowfacet <- function(base = 12, color_bknd, text_color){
   theme_classic(base_size = base) +
     theme(strip.background = element_blank(),
@@ -33,6 +40,11 @@ theme_flowfacet <- function(base = 12, color_bknd, text_color){
           
  }
 
+#' @description Plot states as tiled cartogram
+#' @param fips State codes
+#' @param pal color palette for each bin level
+#' @param usa_grid the grid layout for plotting with
+#' @param color_bknd Plot background color
 plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
   state_data %>% 
     left_join(fips) %>% # to bind to cartogram grid
@@ -60,6 +72,12 @@ plot_state_cartogram <- function(state_data, fips, pal, usa_grid, color_bknd){
 
 }
 
+#' @description Plot nationa level flow conditions
+#' @param national_data The proportion of sites in each flow condition, daily
+#' @param date_start first day of focal month
+#' @param date_end last day of focal month
+#' @param pal color palette for each bin level
+#' @param color_bknd Plot background color
 plot_national_area <- function(national_data, date_start, date_end, pal, color_bknd){
   
   # to label flow categories
@@ -108,6 +126,14 @@ plot_national_area <- function(national_data, date_start, date_end, pal, color_b
   return(plot_nat)
 }
 
+#' @description Compose the final plot and annotate
+#' @param file_out Filepath to save to
+#' @param plot_left The national plot to position on the left
+#' @param plot_right The state tiles to position on the right
+#' @param date_start first day of focal month
+#' @param width Desired width of output plot
+#' @param height Desired height of output plot
+#' @param color_bknd Plot background color
 combine_plots <- function(file_out, plot_left, plot_right, date_start, width, height, color_bknd){
   
   plot_month <- lubridate::month(date_start, label = TRUE, abbr = FALSE)

--- a/src/prep_data.R
+++ b/src/prep_data.R
@@ -1,3 +1,9 @@
+
+#' @description Bin percentile data into flow condition categories
+#' @param data_in 1 month of streamflow percentiles generated from `gage-conditions-gif` pipeline
+#' @param date_start first day of focal month
+#' @param date_end last day of focal month
+#' @param breaks Percentile values to bin data at
 add_flow_condition <- function(data_in, date_start, date_end, breaks){
   data_in %>% 
     mutate(date = as.Date(dateTime)) %>%
@@ -7,6 +13,9 @@ add_flow_condition <- function(data_in, date_start, date_end, breaks){
   
 }
 
+#' @description Count the total number of observed sites per state each day
+#' @param data_in Binned percentile data
+#' @param dv_site Site data with state localities
 site_count_state <- function(data_in, dv_site){
     data_in %>%
       left_join(dv_site)%>%
@@ -16,6 +25,8 @@ site_count_state <- function(data_in, dv_site){
 
 }
 
+#' @description Count total number of active sites nationally each day
+#' @param data_in Binned percentile data
 site_count_national <- function(data_in){
   data_in %>%
     group_by(date) %>%
@@ -23,6 +34,9 @@ site_count_national <- function(data_in){
   
 }
 
+#' @description Calculate proportion of sites in each percentile bin through time
+#' @param data_in Binned percentile data
+#' @param sites_national Total number of active sites each day
 flow_by_day <- function(data_in, sites_national) {
   data_in %>%
     group_by(date, percentile_cond, percentile_bin) %>%
@@ -31,6 +45,9 @@ flow_by_day <- function(data_in, sites_national) {
     mutate(prop = n_gage/total_gage)
 }
 
+#' @description Calculate proportion of sites in each percentile bin through time
+#' @param data_in Binned percentile data
+#' @param sites_national Total number of active sites each day by state
 flow_by_day_by_state <- function(data_in, dv_site, sites_state) {
   data_in  %>%
     left_join(dv_site) %>% # adds state info for each gage

--- a/src/prep_data.R
+++ b/src/prep_data.R
@@ -1,18 +1,10 @@
-add_flow_condition <- function(data_in, date_start, date_end){
+add_flow_condition <- function(data_in, date_start, date_end, breaks){
   data_in %>% 
-    mutate(date = as.Date(dateTime),
-           cond = 
-             case_when(
-               per < 0.05 ~ 'Driest',
-               per >= 0.05 & per < 0.1 ~ "Drier",
-               per >= 0.1 & per < 0.25 ~ "Dry", 
-               per >= 0.25 & per < 0.75 ~ "Normal",
-               per >= 0.75 & per < 0.9 ~ "Wet", 
-               per >= 0.9 & per < 0.95 ~ "Wetter", 
-               per >= 0.95 ~ "Wettest"
-             ),
-           cond = factor(cond, ordered = TRUE, levels = c("Driest", "Drier", "Dry", "Normal","Wet","Wetter", "Wettest"))) %>%
-    filter(date >= date_start, date <= date_end, !is.na(cond)) 
+    mutate(date = as.Date(dateTime)) %>%
+    filter(date >= date_start, date <= date_end, !is.na(per)) %>%
+    mutate(percentile_bin = cut(per, breaks = breaks, include.lowest = TRUE),
+           percentile_cond = factor(percentile_bin, labels = c("Driest", "Drier", "Dry", "Normal","Wet","Wetter", "Wettest")))
+  
 }
 
 site_count_state <- function(data_in, dv_site){
@@ -33,7 +25,7 @@ site_count_national <- function(data_in){
 
 flow_by_day <- function(data_in, sites_national) {
   data_in %>%
-    group_by(date, cond) %>%
+    group_by(date, percentile_cond, percentile_bin) %>%
     summarize(n_gage = length(unique(site_no))) %>%
     left_join(sites_national) %>%
     mutate(prop = n_gage/total_gage)
@@ -42,13 +34,13 @@ flow_by_day <- function(data_in, sites_national) {
 flow_by_day_by_state <- function(data_in, dv_site, sites_state) {
   data_in  %>%
     left_join(dv_site) %>% # adds state info for each gage
-    group_by(state_cd, date, cond) %>% # aggregate by state, day, flow condition
+    group_by(state_cd, date, percentile_cond) %>% # aggregate by state, day, flow condition
     summarize(n_gage = length(unique(site_no)))  %>%
     left_join(sites_state) %>% # add total_gage
     mutate(prop = n_gage/total_gage) %>% # proportion of gages
-    pivot_wider(id_cols = !n_gage, names_from = cond, values_from = prop, values_fill = 0) %>% # complete data for timepoints with 0 gages
+    pivot_wider(id_cols = !n_gage, names_from = percentile_cond, values_from = prop, values_fill = 0) %>% # complete data for timepoints with 0 gages
     pivot_longer(cols = c("Normal", "Wet", "Wetter", "Wettest", "Driest", "Drier", "Dry"), 
-                 names_to = "cond", values_to = "prop")
+                 names_to = "percentile_cond", values_to = "prop")
 
 }
 

--- a/src/prep_data.R
+++ b/src/prep_data.R
@@ -4,12 +4,12 @@
 #' @param date_start first day of focal month
 #' @param date_end last day of focal month
 #' @param breaks Percentile values to bin data at
-add_flow_condition <- function(data_in, date_start, date_end, breaks){
+add_flow_condition <- function(data_in, date_start, date_end, breaks, break_labels = c("Driest", "Drier", "Dry", "Normal","Wet","Wetter", "Wettest")){
   data_in %>% 
     mutate(date = as.Date(dateTime)) %>%
     filter(date >= date_start, date <= date_end, !is.na(per)) %>%
     mutate(percentile_bin = cut(per, breaks = breaks, include.lowest = TRUE),
-           percentile_cond = factor(percentile_bin, labels = c("Driest", "Drier", "Dry", "Normal","Wet","Wetter", "Wettest")))
+           percentile_cond = factor(percentile_bin, labels = break_labels))
   
 }
 


### PR DESCRIPTION
This adds steps to the pipeline to create the legend. This was done by:
- adding step to define breaks in pipeline via `percentile_breaks`
- adding a binned variable to reflect percentile bins, named `percentile_bin`
- using the new binned variable to plot and define a guide using `guide_colorsteps`
- including some styling steps in the final plot composition

I also added comments and function descriptions throughout to document the pipeline steps. The final plot output is:

<img width="1524" alt="image" src="https://user-images.githubusercontent.com/17803537/170145669-32b631ae-f164-49d7-bd62-c7cd245c7848.png">

